### PR TITLE
fix: use __version__ instead of hardcoded version string

### DIFF
--- a/src/glassbox/server.py
+++ b/src/glassbox/server.py
@@ -14,7 +14,8 @@ try:
 except Exception:
     pass  # fall back to env var
 
-mcp = FastMCP("GlassBox AI v0.3.0")
+from . import __version__
+mcp = FastMCP(f"GlassBox AI v{__version__}")
 orch = MultiAgentOrchestrator()
 
 

--- a/tests/test_glassbox.py
+++ b/tests/test_glassbox.py
@@ -181,3 +181,10 @@ def test_20_analyze_is_async():
     """analyze tool is an async function."""
     from glassbox.server import analyze
     assert asyncio.iscoroutinefunction(analyze.__wrapped__ if hasattr(analyze, "__wrapped__") else analyze)
+
+
+def test_21_version_string_matches():
+    """Server version string matches __version__ from __init__.py."""
+    from glassbox import __version__
+    from glassbox.server import mcp
+    assert mcp.name == f"GlassBox AI v{__version__}"


### PR DESCRIPTION
Closes #14

## Changes
Import `__version__` from `__init__.py` and use f-string in `FastMCP()` name.

## Generated by
🤖 **GlassBox AI Agent** — automated fix triggered by `agent` label.

## Tests
✅ 21/21 unit tests passing (including new `test_21_version_string_matches`).
CI pipeline will verify integration tests and Docker build.