### PR TITLE
fix: update agent prompts from standup meeting to design review

### DIFF
--- a/src/glassbox/orchestrator.py
+++ b/src/glassbox/orchestrator.py
@@ -6,9 +6,9 @@ from openai import AsyncOpenAI
 from .trust_db import TrustDB
 
 AGENTS = {
-    "architect": ("gpt-4o", 0.3, "You are @architect. Think long-term, scalability, what breaks at scale. Talk like you're in a standup meeting — direct, opinionated, no fluff. Reference @pragmatist/@critic by name. Agree or disagree sharply."),
-    "pragmatist": ("gpt-4o", 0.5, "You are @pragmatist. Ship fast, iterate, cut scope. Talk like you're in a standup meeting — direct, opinionated, no fluff. Reference @architect/@critic by name. Push back on overengineering."),
-    "critic":     ("gpt-4o-mini", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a standup meeting — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
+    "architect": ("gpt-4o", 0.3, "You are @architect. Think long-term, scalability, what breaks at scale. Talk like you're in a design review — direct, opinionated, no fluff. Reference @pragmatist/@critic by name. Agree or disagree sharply."),
+    "pragmatist": ("gpt-4o", 0.5, "You are @pragmatist. Ship fast, iterate, cut scope. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@critic by name. Push back on overengineering."),
+    "critic":     ("gpt-4o-mini", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
 }
 ROUNDS = [
     "ROUND 1: State your position. Be direct, no bullet points.",

--- a/tests/test_glassbox.py
+++ b/tests/test_glassbox.py
@@ -188,3 +188,12 @@ def test_21_version_string_matches():
     from glassbox import __version__
     from glassbox.server import mcp
     assert mcp.name == f"GlassBox AI v{__version__}"
+
+
+def test_22_prompts_updated_to_design_review():
+    """Ensure all agent prompts use 'design review' instead of 'standup meeting'."""
+    from glassbox.orchestrator import AGENTS
+    for name, t in AGENTS.items():
+        assert "design review" in t[2], f"{name} prompt not updated"
+        assert "standup meeting" not in t[2], f"{name} prompt still contains old text"
+


### PR DESCRIPTION
Closes #16

## Changes
All 3 agent prompts in `orchestrator.py` updated: "standup meeting" → "design review".

## Generated by
🤖 **GlassBox AI Agent** — automated fix triggered by `agent` label.

## Tests
✅ 22/22 unit tests passing (including new `test_22_prompts_updated_to_design_review`).
CI pipeline will verify integration tests and Docker build.