### PR TITLE
feat: dashboard v2 - success rate chart + conversion funnel

### DIFF
--- a/scripts/dashboard/config.py
+++ b/scripts/dashboard/config.py
@@ -3,7 +3,7 @@
 import os
 
 REPO = os.environ.get("GITHUB_REPOSITORY", "agentic-trust-labs/glassbox-ai")
-WORKFLOW_NAME = "Agent Fix"
+WORKFLOW_NAME = "GlassBox Agent"
 AGENT_LABELS = ["glassbox-agent", "agent"]
 AGENT_MENTIONS = ["@glassbox-agent", "@glassbox_agent"]
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "docs", "dashboard")


### PR DESCRIPTION
## Changes
- Fix `WORKFLOW_NAME`: 'Agent Fix' → 'GlassBox Agent' in dashboard config
- Add SVG **success rate over time** line chart (color-coded: green ≥50%, yellow ≥30%, red <30%)
- Add SVG **conversion funnel** (assigned → analyzed → PR created → merged)
- Add favicon + repo link in subtitle

## Preview
Dashboard will auto-regenerate on next agent run via the workflow.