### PR TITLE
fix: fix: correct typo in critic model name from 'gpt-4o-mni' to 'gpt-4o-mini'

### DIFF
--- a/src/glassbox/orchestrator.py
+++ b/src/glassbox/orchestrator.py
@@ -9,7 +9,7 @@ from .trust_db import TrustDB
 AGENTS = {
     "architect": ("gpt-4o", 0.3, "You are @architect. Think long-term, scalability, what breaks at scale. Talk like you're in a design review — direct, opinionated, no fluff. Reference @pragmatist/@critic by name. Agree or disagree sharply."),
     "pragmatist": ("gpt-4o", 0.5, "You are @pragmatist. Ship fast, iterate, cut scope. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@critic by name. Push back on overengineering."),
-    "critic":     ("gpt-4o-mni", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
+    "critic":     ("gpt-4o-mini", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
 }
 ROUNDS = [
     "ROUND 1: State your position. Be direct, use bullet points.",

--- a/tests/test_glassbox.py
+++ b/tests/test_glassbox.py
@@ -213,3 +213,9 @@ def test_imports_are_correct():
     except ImportError as e:
         assert False, f"Import failed: {e}"
     assert True
+
+
+def test_critic_model_name():
+    from glassbox.orchestrator import AGENTS
+    assert AGENTS['critic'][0] == 'gpt-4o-mini', "Critic model name should be 'gpt-4o-mini'"
+


### PR DESCRIPTION
Closes #43

## Changes
fix: correct typo in critic model name from 'gpt-4o-mni' to 'gpt-4o-mini'

## Strategy
Corrected the typo in the critic model name within the orchestrator configuration and added a test to ensure the model name is correct.

## Generated by
🤖 **GlassBox Agent v0.3-beta** - 5-message protocol

## Tests
✅ ============================== 25 passed in 1.16s ==============================
