### PR TITLE
fix: fix: correct ROUND 1 instruction to 'no bullet points'

### DIFF
--- a/src/glassbox/orchestrator.py
+++ b/src/glassbox/orchestrator.py
@@ -12,7 +12,7 @@ AGENTS = {
     "critic":     ("gpt-4o-mni", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
 }
 ROUNDS = [
-    "ROUND 1: State your position. Be direct, use bullet points.",
+    "ROUND 1: State your position. Be direct, no bullet points.",
     "ROUND 2: React to others. Say 'I agree with @X' or 'I disagree with @X because'. Be sharp.",
     "ROUND 3: Final position. If you changed your mind, say CHANGED: and who influenced you. If not, say HOLDING: and why.",
 ]

--- a/tests/test_glassbox.py
+++ b/tests/test_glassbox.py
@@ -213,3 +213,8 @@ def test_imports_are_correct():
     except ImportError as e:
         assert False, f"Import failed: {e}"
     assert True
+
+
+def test_round_1_instruction_no_bullet_points():
+    from glassbox.orchestrator import ROUNDS
+    assert ROUNDS[0] == "ROUND 1: State your position. Be direct, no bullet points."


### PR DESCRIPTION
Closes #41

## Changes
fix: correct ROUND 1 instruction to 'no bullet points'

## Strategy
Updated the specific instruction in the ROUNDS list to ensure agents do not use bullet points in ROUND 1, and added a test to verify the change.

## Generated by
🤖 **GlassBox Agent v0.3-beta** - 5-message protocol

## Tests
✅ ============================== 25 passed in 1.16s ==============================
