### PR TITLE
fix: Fix fallback trust score for unknown agents

### DIFF
--- a/src/glassbox/trust_db.py
+++ b/src/glassbox/trust_db.py
@@ -29,7 +29,7 @@ class TrustDB:
         conn = sqlite3.connect(self.db_path)
         result = conn.execute("SELECT score FROM trust_scores WHERE agent = ?", (agent,)).fetchone()
         conn.close()
-        return result[0] if result else 0.50
+        return result[0] if result else 0.85
 
     def get_all_scores(self) -> Dict[str, float]:
         conn = sqlite3.connect(self.db_path)


### PR DESCRIPTION
Closes #54

## Changes
Fix fallback trust score for unknown agents

## Strategy
Identify the incorrect fallback value in the specified line and replace it with the correct value as per the issue description.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
