### PR TITLE
fix: Fix trust score initialization to 0.85

### DIFF
--- a/src/glassbox/trust_db.py
+++ b/src/glassbox/trust_db.py
@@ -21,7 +21,7 @@ class TrustDB:
             )
         """)
         for agent in ["architect", "pragmatist", "critic"]:
-            conn.execute("INSERT OR IGNORE INTO trust_scores (agent, score) VALUES (?, 0.50)", (agent,))
+            conn.execute("INSERT OR IGNORE INTO trust_scores (agent, score) VALUES (?, 0.85)", (agent,))
         conn.commit()
         conn.close()
 


### PR DESCRIPTION
Closes #58

## Changes
Fix trust score initialization to 0.85

## Strategy
Locate the line with the incorrect trust score value and update it to the correct value of 0.85 as specified in the issue.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
