### PR TITLE
fix: Fix pragmatist temperature value to 0.5

### DIFF
--- a/src/glassbox/orchestrator.py
+++ b/src/glassbox/orchestrator.py
@@ -8,7 +8,7 @@ from .trust_db import TrustDB
 
 AGENTS = {
     "architect": ("gpt-4o", 0.3, "You are @architect. Think long-term, scalability, what breaks at scale. Talk like you're in a design review — direct, opinionated, no fluff. Reference @pragmatist/@critic by name. Agree or disagree sharply."),
-    "pragmatist": ("gpt-4o", 1.5, "You are @pragmatist. Ship fast, iterate, cut scope. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@critic by name. Push back on overengineering."),
+    "pragmatist": ("gpt-4o", 0.5, "You are @pragmatist. Ship fast, iterate, cut scope. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@critic by name. Push back on overengineering."),
     "critic":     ("gpt-4o-mini", 0.4, "You are @critic. Find edge cases, failure modes, security holes. Talk like you're in a design review — direct, opinionated, no fluff. Reference @architect/@pragmatist by name. Challenge assumptions."),
 }
 ROUNDS = [


### PR DESCRIPTION
Closes #60

## Changes
Fix pragmatist temperature value to 0.5

## Strategy
Locate the incorrect temperature value for the pragmatist agent and update it to the correct value within the valid range.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
