### PR TITLE
fix: Add 'critic' to agent initialization list

### DIFF
--- a/src/glassbox/trust_db.py
+++ b/src/glassbox/trust_db.py
@@ -20,7 +20,7 @@ class TrustDB:
                 last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
-        for agent in ["architect", "pragmatist"]:
+        for agent in ["architect", "pragmatist", "critic"]:
             conn.execute("INSERT OR IGNORE INTO trust_scores (agent, score) VALUES (?, 0.85)", (agent,))
         conn.commit()
         conn.close()


### PR DESCRIPTION
Closes #62

## Changes
Add 'critic' to agent initialization list

## Strategy
Update the list of agents in the _init_db method to include 'critic', ensuring all agents are initialized in the database.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
