### PR TITLE
fix: Fix trust score ceiling to 1.0

### DIFF
--- a/src/glassbox/trust_db.py
+++ b/src/glassbox/trust_db.py
@@ -56,7 +56,7 @@ class TrustDB:
             old_score, correct, total = result
         correct += 1 if was_correct else 0
         total += 1
-        new_score = max(0.3, min(0.9, old_score + 0.1 * ((1.0 if was_correct else 0.0) - old_score)))
+        new_score = max(0.3, min(1.0, old_score + 0.1 * ((1.0 if was_correct else 0.0) - old_score)))
         conn.execute("UPDATE trust_scores SET score=?, correct_count=?, total_count=?, last_updated=CURRENT_TIMESTAMP WHERE agent=?", (new_score, correct, total, agent))
         conn.commit()
         conn.close()


### PR DESCRIPTION
Closes #64

## Changes
Fix trust score ceiling to 1.0

## Strategy
Locate the line with the incorrect ceiling value and update it to 1.0 as specified in the issue description.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
