### PR TITLE
fix: Fix memory query to use full title

### DIFF
--- a/src/glassbox_agent/memory/store.py
+++ b/src/glassbox_agent/memory/store.py
@@ -51,7 +51,7 @@ class MemoryStore:
 
     def format_for_prompt(self, title: str) -> str:
         """Format relevant reflections for injection into LLM prompt."""
-        relevant = self.query(title.split()[0] if title else "", limit=3)
+        relevant = self.query(title if title else "", limit=3)
         if not relevant:
             return ""
         lines = ["PAST REFLECTIONS (learn from these):"]


### PR DESCRIPTION
Closes #68

## Changes
Fix memory query to use full title

## Strategy
Update the query to use the full title instead of just the first word to improve relevance of results.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
