### PR TITLE
fix: Expand file filter to include test files

### DIFF
--- a/src/glassbox_agent/cli.py
+++ b/src/glassbox_agent/cli.py
@@ -53,7 +53,7 @@ def run_pipeline(issue_number: int) -> None:
     print("\n🎯 Manager: Classifying...")
     sources = {}
     for f in reader.list_files((".py",)):
-        if f.startswith("src/glassbox/"):
+if f.startswith("src/glassbox/") or f.startswith("tests/"):
             ok, content = reader.read_raw(f)
             if ok:
                 sources[f] = content


### PR DESCRIPTION
Closes #69

## Changes
Expand file filter to include test files

## Strategy
Modify the file inclusion logic to also include files starting with 'tests/' to ensure test files are considered in the agent context.

## Template
`swapped_args` — Swapped Arguments/Order

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
