### PR TITLE
fix: Extract difficulty from LLM response

### DIFF
--- a/src/glassbox_agent/agents/manager.py
+++ b/src/glassbox_agent/agents/manager.py
@@ -92,7 +92,7 @@ class Manager(BaseAgent):
         edge_cases = [EdgeCase(**ec) for ec in data.get("edge_cases", [])]
 
         return TriageResult(
-            template_id=data["template_id"],
+    difficulty=data.get("difficulty", "easy"),
             confidence=data.get("confidence", 0.5),
             skip_reason=data.get("skip_reason"),
             soft_aspects=data.get("soft_aspects", []),


### PR DESCRIPTION
Closes #70

## Changes
Extract difficulty from LLM response

## Strategy
Add the 'difficulty' field extraction with a default value to the TriageResult construction.

## Template
`swapped_args` — Swapped Arguments/Order

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
