### PR TITLE
fix: Replace casual greeting with professional prefix

### DIFF
--- a/src/glassbox_agent/agents/junior_dev.py
+++ b/src/glassbox_agent/agents/junior_dev.py
@@ -131,7 +131,7 @@ class JuniorDev(BaseAgent):
 
     def format_comment(self, fix: Fix) -> str:
         """Format fix details as a GitHub comment."""
-        lines = ["🫡 Got it, boss!\n"]
+lines = ["🔧 **GlassBox JuniorDev** — Generating fix...\n"]
         for edit in fix.edits:
             lines.append(f"**{edit.file}** line {edit.start_line}-{edit.end_line}:")
             lines.append(f"```python\n{edit.new_text}```")


### PR DESCRIPTION
Closes #76

## Changes
Replace casual greeting with professional prefix

## Strategy
Update the specific line to replace the casual greeting with the professional prefix as described in the issue.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
