### PR TITLE
fix: Fix diff formatting in JuniorDev comment

### DIFF
--- a/src/glassbox_agent/agents/junior_dev.py
+++ b/src/glassbox_agent/agents/junior_dev.py
@@ -134,7 +134,7 @@ class JuniorDev(BaseAgent):
         lines = ["🫡 Got it, boss!\n"]
         for edit in fix.edits:
             lines.append(f"**{edit.file}** line {edit.start_line}-{edit.end_line}:")
-            lines.append(f"```python\n{edit.new_text}```")
+lines.append(f"```diff\n- {edit.old_text}\n+ {edit.new_text}```")
         lines.append(f"\n**Strategy:** {fix.strategy}")
         lines.append(f"**Lines changed:** {sum(e.end_line - e.start_line + 1 for e in fix.edits)}")
         lines.append("\n🧪 **Tester**, over to you.")


### PR DESCRIPTION
Closes #77

## Changes
Fix diff formatting in JuniorDev comment

## Strategy
Update the line to use diff formatting by including both old and new text with '-' and '+' indicators.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
