### PR TITLE
fix: Truncate failure messages to 100 chars

### DIFF
--- a/src/glassbox_agent/agents/tester.py
+++ b/src/glassbox_agent/agents/tester.py
@@ -87,7 +87,7 @@ class Tester(BaseAgent):
             for f in result.failures[:5]:
                 name = f.test_name if isinstance(f, object) and hasattr(f, 'test_name') else f.get("test_name", "?")
                 msg = f.message if isinstance(f, object) and hasattr(f, 'message') else f.get("message", "?")
-                lines.append(f"- `{name}`: {msg[:200]}")
+        lines.append(f"- `{name}`: {msg[:100]}")
 
         # Verdict
         lines.append("")


### PR DESCRIPTION
Closes #80

## Changes
Truncate failure messages to 100 chars

## Strategy
Directly replace the truncation length from 200 to 100 as specified in the issue.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
