### PR TITLE
fix: Remove ID codes from hard aspects display

### DIFF
--- a/src/glassbox_agent/agents/manager.py
+++ b/src/glassbox_agent/agents/manager.py
@@ -113,7 +113,7 @@ class Manager(BaseAgent):
 
         lines.append("")
         lines.append("**Aspects:**")
-        hard = " · ".join(f"HA{i+1} {a['name']}" for i, a in enumerate(HARD_ASPECTS))
+hard = " · ".join(f"{a['name']}" for i, a in enumerate(HARD_ASPECTS))
         lines.append(f"- 🔴 {hard}")
         if triage.soft_aspects:
             soft = " · ".join(f"{a.get('id', '?')} {a.get('name', '?')}" for a in triage.soft_aspects)


### PR DESCRIPTION
Closes #83

## Changes
Remove ID codes from hard aspects display

## Strategy
Directly modify the string formatting to exclude the ID codes, ensuring the display is user-friendly.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v2** — template-driven multi-agent
