### PR TITLE
fix: Add template description to Manager briefing

### DIFF
--- a/src/glassbox_agent/agents/manager.py
+++ b/src/glassbox_agent/agents/manager.py
@@ -105,7 +105,7 @@ class Manager(BaseAgent):
         lines = []
         lines.append(f"| | |")
         lines.append(f"|---|---|")
-        lines.append(f"| 📋 **Template** | `{template.id}` — {template.name} |")
+        lines.append(f"| 📋 **Template** | `{template.id}` — {template.name}: {template.description} |")
         lines.append(f"| 🎯 **Confidence** | {triage.confidence:.0%} |")
         if triage.skip_reason:
             lines.append(f"| ⏭️ **Skip** | {triage.skip_reason} |")


### PR DESCRIPTION
Closes #82

## Changes
Add template description to Manager briefing

## Strategy
Append the template description to the existing string format in the specified line.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
