### PR TITLE
fix: Remove HA prefix codes from hard aspects display

### DIFF
--- a/src/glassbox_agent/agents/manager.py
+++ b/src/glassbox_agent/agents/manager.py
@@ -113,7 +113,7 @@ class Manager(BaseAgent):
 
         lines.append("")
         lines.append("**Aspects:**")
-        hard = " · ".join(f"HA{i+1} {a['name']}" for i, a in enumerate(HARD_ASPECTS))
+        hard = " · ".join(f"{a['name']}" for i, a in enumerate(HARD_ASPECTS))
         lines.append(f"- 🔴 {hard}")
         if triage.soft_aspects:
             soft = " · ".join(f"{a.get('id', '?')} {a.get('name', '?')}" for a in triage.soft_aspects)


### PR DESCRIPTION
Closes #83

## Changes
Remove HA prefix codes from hard aspects display

## Strategy
Directly remove the prefix codes from the string formatting in the specified line.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
