### PR TITLE
fix: Make file paths clickable GitHub links

### DIFF
--- a/src/glassbox_agent/agents/junior_dev.py
+++ b/src/glassbox_agent/agents/junior_dev.py
@@ -133,7 +133,7 @@ class JuniorDev(BaseAgent):
         """Format fix details as a GitHub comment."""
         lines = ["🔧 **GlassBox JuniorDev** — Generating fix...\n"]
         for edit in fix.edits:
-            lines.append(f"**{edit.file}** line {edit.start_line}-{edit.end_line}:")
+            lines.append(f"**[{edit.file}](https://github.com/{self.settings.repo}/blob/main/{edit.file}#L{edit.start_line})** line {edit.start_line}-{edit.end_line}:")
             lines.append(f"```python\n{edit.new_text}```")
         lines.append(f"\n**Strategy:** {fix.strategy}")
         lines.append(f"**Lines changed:** {sum(e.end_line - e.start_line + 1 for e in fix.edits)}")


### PR DESCRIPTION
Closes #81

## Changes
Make file paths clickable GitHub links

## Strategy
Modify the string formatting to include a GitHub URL, ensuring the file path is clickable and points to the correct line.

## Template
`typo_fix` — Typo Fix

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
