### PR TITLE
fix: one-line commit message

### DIFF
--- a/src/glassbox_agent/agents/junior_dev.py
+++ b/src/glassbox_agent/agents/junior_dev.py
@@ -134,7 +134,7 @@ class JuniorDev(BaseAgent):
         lines = ["🔧 **GlassBox JuniorDev** — Generating fix...\n"]
         for edit in fix.edits:
             lines.append(f"**[{edit.file}](https://github.com/{self.settings.repo}/blob/main/{edit.file}#L{edit.start_line})** line {edit.start_line}-{edit.end_line}:")
-            lines.append(f"```python\n{edit.new_text}```")
+            lines.append(f"```diff\n- {edit.old_text}\n+ {edit.new_text}```")
         lines.append(f"\n**Strategy:** {fix.strategy}")
         lines.append(f"**Lines changed:** {sum(e.end_line - e.start_line + 1 for e in fix.edits)}")
         lines.append("\n🧪 **Tester**, over to you.")


### PR DESCRIPTION
Closes #77

## Changes
one-line commit message

## Strategy
Replace the existing line with a diff format to show both old and new text.

## Template
`swapped_args` — Swapped Arguments/Order

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
