### PR TITLE
fix: Remove HC prefix codes from hard challenges display

### DIFF
--- a/src/glassbox_agent/agents/manager.py
+++ b/src/glassbox_agent/agents/manager.py
@@ -121,7 +121,7 @@ class Manager(BaseAgent):
 
         lines.append("")
         lines.append("**Challenges:**")
-        hard_c = " · ".join(f"HC{i+1} {c['name']}" for i, c in enumerate(HARD_CHALLENGES))
+        hard_c = " · ".join(f"{c['name']}" for i, c in enumerate(HARD_CHALLENGES))
         lines.append(f"<details><summary>🔴 Hard Challenges (5)</summary>\n\n- {hard_c}\n</details>")
         if triage.soft_challenges:
             for sc in triage.soft_challenges:


### PR DESCRIPTION
Closes #102

## Changes
Remove HC prefix codes from hard challenges display

## Strategy
Identify and remove the HC prefix codes from the hard challenges display line to ensure end users see only the challenge names.

## Template
`typo_fix` — Typo Fix

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
