### PR TITLE
fix: Remove unused mcp dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # GlassBox AI Dependencies
 
 # MCP Protocol (Model Context Protocol)
-mcp
+
 
 # OpenAI API
 openai>=1.54.0


### PR DESCRIPTION
Closes #106

## Changes
Remove unused mcp dependency from requirements.txt

## Strategy
Remove the line containing 'mcp' from requirements.txt to ensure it is not installed unnecessarily.

## Template
`typo_fix` — Typo Fix

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
