### PR TITLE
fix: Pin exact version of openai dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 
 # OpenAI API
-openai>=1.54.0
+openai==1.82.0
 
 # Future: Multi-model support
 # anthropic>=0.40.0


### PR DESCRIPTION
Closes #112

## Changes
Pin exact version of openai dependency

## Strategy
Identify the line in requirements.txt with the openai dependency and change the version specifier from >= to == with the specified version.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
