### PR TITLE
fix: Pin pydantic version to 2.11.1 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ openai==1.82.0
 # Database (SQLite is built-in to Python)
 
 # Agent v2
-pydantic>=2.0.0
+pydantic==2.11.1
 pyyaml>=6.0
 
 # Development


### PR DESCRIPTION
Closes #116

## Changes
Pin pydantic version to 2.11.1 in requirements.txt

## Strategy
Update the version specifier for pydantic in requirements.txt to ensure a specific version is used, preventing potential compatibility issues with future versions.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
