### PR TITLE
fix: Pin pyyaml version to 6.0.2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ openai==1.82.0
 
 # Agent v2
 pydantic==2.11.1
-pyyaml>=6.0
+pyyaml==6.0.2
 
 # Development
 python-dotenv>=1.0.0


### PR DESCRIPTION
Closes #118

## Changes
Pin pyyaml version to 6.0.2 in requirements.txt

## Strategy
Modify the version specification for pyyaml in requirements.txt to ensure the exact version 6.0.2 is used, preventing potential compatibility issues with future versions.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
