### PR TITLE
fix: Pin pytest version to 8.3.5 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml==6.0.2
 
 # Development
 python-dotenv>=1.0.0
-pytest>=8.0.0
+pytest==8.3.5
 
 # Dev-only (requires Python 3.12+, install separately):
 # pip install mcp-hmr


### PR DESCRIPTION
Closes #120

## Changes
Pin pytest version to 8.3.5 in requirements.txt

## Strategy
Update the version specification for pytest in requirements.txt to ensure a specific version is used, preventing potential compatibility issues with future versions.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
