### PR TITLE
fix: Pin python-dotenv version to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pydantic==2.11.1
 pyyaml==6.0.2
 
 # Development
-python-dotenv>=1.0.0
+python-dotenv==1.1.0
 pytest==8.3.5
 
 # Dev-only (requires Python 3.12+, install separately):


### PR DESCRIPTION
Closes #122

## Changes
Pin python-dotenv version to 1.1.0

## Strategy
Modify the version specification for python-dotenv in requirements.txt to ensure a specific version is used, preventing potential compatibility issues with newer versions.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
