### PR TITLE
fix: Set temperature_code to 0.1 for deterministic code generation

### DIFF
--- a/src/glassbox_agent/core/settings.py
+++ b/src/glassbox_agent/core/settings.py
@@ -11,7 +11,7 @@ class Settings(BaseModel):
     model: str = "gpt-4o"
     model_classify: str = "gpt-4o-mini"
     temperature_classify: float = 0.3
-    temperature_code: float = 1.0
+    temperature_code: float = 0.1
     temperature_review: float = 0.3
     max_retries: int = 2
     templates_dir: str = Field(default_factory=lambda: os.path.join(os.path.dirname(__file__), "..", "templates"))


### PR DESCRIPTION
Closes #134

## Changes
Set temperature_code to 0.1 for deterministic code generation

## Strategy
Corrected the temperature_code in settings.py to ensure deterministic and precise output for code generation.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
