### PR TITLE
fix: Fix default reaction emoji to '+1'

### DIFF
--- a/src/glassbox_agent/tools/github_client.py
+++ b/src/glassbox_agent/tools/github_client.py
@@ -48,7 +48,7 @@ class GitHubClient:
             return comment_id
         return self.post_comment(issue_number, body)
 
-    def add_reaction(self, comment_id: int, reaction: str = "confused") -> bool:
+    def add_reaction(self, comment_id: int, reaction: str = "+1") -> bool:
         """Add a reaction to a comment (thumbs up ack)."""
         if comment_id <= 0:
             return False


### PR DESCRIPTION
Closes #137

## Changes
Fix default reaction emoji to '+1'

## Strategy
Locate the specified line in the GitHubClient file and update the default reaction emoji from 'confused' to '+1'.

## Template
`typo_fix` — Typo Fix

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
