### PR TITLE
fix: Correct bounds check for 1-indexed lines.

### DIFF
--- a/src/glassbox_agent/tools/code_editor.py
+++ b/src/glassbox_agent/tools/code_editor.py
@@ -37,7 +37,7 @@ class CodeEditor:
         with open(full) as f:
             lines = f.readlines()
 
-        if edit.start_line < 0 or edit.end_line > len(lines):
+        if edit.start_line < 1 or edit.end_line > len(lines):
             return False, f"Line range {edit.start_line}-{edit.end_line} out of bounds ({len(lines)} lines)"
 
         # Indent-Capture-Reapply: preserve original indentation (RooCode pattern)


### PR DESCRIPTION
Closes #135

## Changes
Correct bounds check for 1-indexed lines.

## Strategy
Update the off-by-one error in the bounds check to correctly handle line numbers starting from 1.

## Template
`typo_fix` — Typo Fix

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
