### PR TITLE
fix: fix fuzzy_find threshold value

### DIFF
--- a/src/glassbox_agent/tools/code_editor.py
+++ b/src/glassbox_agent/tools/code_editor.py
@@ -91,7 +91,7 @@ class CodeEditor:
         return max(original_count, new_count)
 
     @staticmethod
-    def fuzzy_find(content: str, target: str, threshold: float = 0.3) -> tuple[int, float]:
+    def fuzzy_find(content: str, target: str, threshold: float = 0.6) -> tuple[int, float]:
         """Find best fuzzy match for target in content lines. Returns (line_number, ratio)."""
         lines = content.split("\n")
         best_line, best_ratio = 0, 0.0


### PR DESCRIPTION
Closes #138

## Changes
fix fuzzy_find threshold value

## Strategy
Simply updated the default threshold value from 0.3 to 0.6 to address the false positive matches without altering any other logic.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
