### PR TITLE
fix: Fix max_retries to 2 in settings.py

### DIFF
--- a/src/glassbox_agent/core/settings.py
+++ b/src/glassbox_agent/core/settings.py
@@ -13,6 +13,6 @@ class Settings(BaseModel):
     temperature_classify: float = 0.3
     temperature_code: float = 1.0
     temperature_review: float = 0.3
-    max_retries: int = 0
+    max_retries: int = 2
     templates_dir: str = Field(default_factory=lambda: os.path.join(os.path.dirname(__file__), "..", "templates"))
     reflections_path: str = Field(default_factory=lambda: os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "data", "reflections.json"))


### PR DESCRIPTION
Closes #144

## Changes
Fix max_retries to 2 in settings.py

## Strategy
Locate the line with max_retries setting and change its value from 0 to 2. Add a test to verify the correct setting.

## Template
`wrong_value` — Wrong Numeric Value

## Generated by
🤖 **GlassBox Agent v1** — template-driven multi-agent
